### PR TITLE
Fix false positive removal on windows due to IOError

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,5 +16,9 @@ jobs:
 - template: job--pre-commit.yml@asottile
 - template: job--python-tox.yml@asottile
   parameters:
+    toxenvs: [py37]
+    os: windows
+- template: job--python-tox.yml@asottile
+  parameters:
     toxenvs: [pypy3, py36, py37, py38]
     os: linux

--- a/yesqa.py
+++ b/yesqa.py
@@ -118,14 +118,17 @@ def fix_file(filename: str) -> int:
     if src_no_comments == contents_text:
         return 0
 
-    with tempfile.NamedTemporaryFile(
+    fd, path = tempfile.mkstemp(
         dir=os.path.dirname(filename),
         prefix=os.path.basename(filename),
         suffix='.py',
-    ) as tmpfile:
-        tmpfile.write(src_no_comments.encode())
-        tmpfile.flush()
-        flake8_results = _run_flake8(tmpfile.name)
+    )
+    try:
+        with open(fd, 'wb') as f:
+            f.write(src_no_comments.encode())
+        flake8_results = _run_flake8(path)
+    finally:
+        os.remove(path)
 
     if any('E999' in v for v in flake8_results.values()):
         print(f'{filename}: syntax error (skipping)')


### PR DESCRIPTION
This implements the changes discussed in #45. Additionally, I also added a test for macOS.
Though I'm not sure about the changes in the azure-pipeline, since I never worked with azure and templates for them (directly transitioned from Travis + appveyor to github-actions last year).

When I tried to run the azure pipeline on my since I got the following error.
`Repository asottile references endpoint github which does not exist or is not authorized for use`

So let's see if it works.

closes #45 